### PR TITLE
Add support for significand when building on macOS.

### DIFF
--- a/src/qindex.cpp
+++ b/src/qindex.cpp
@@ -54,8 +54,8 @@
  */
 using namespace std;
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-// Linux and BSD have this function in the library; Windows doesn't.
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__APPLE__)
+// Linux and BSD have this function in the library; Windows and macOS do not.
 double significand(double x)
 {
   int dummy;

--- a/src/qindex.h
+++ b/src/qindex.h
@@ -33,7 +33,7 @@
 
 class PostScript;
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__APPLE__)
 double significand(double x);
 #endif
 


### PR DESCRIPTION
macOS does not have built in support for `significand`, so utilize `significand` as defined `bezitope` source code.

This build on macOS Monterey using MacPorts for Qt5, etc..  Tests that failed are

```The following tests FAILED:
	  8 - drawobj (Not Run)
	 15 - segment (Failed)
	 17 - spiral (Failed)
	 31 - convertgeoid1 (Failed)
```